### PR TITLE
implemented todoist activity data with yaml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,12 @@
+env/
+venv/
+.vscode/
+.envrc
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]
 *$py.class
-env/
-.vscode/
 
 # C extensions
 *.so

--- a/README.md
+++ b/README.md
@@ -1,9 +1,13 @@
 # todoist-export
 
-export todoist activity data
+Export todoist data
 
 ## usage
 
 ```bash
-
+python3 main.py --data daily-report --from-date 2021-01-05 --until-date 2021-01-09
 ```
+
+## dev
+
+pytest runs with GitHub Actions. Make sure impl test and it passes.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
 # todoist-export
+
 export todoist activity data
+
+## usage
+
+```bash
+
+```

--- a/main.py
+++ b/main.py
@@ -9,13 +9,12 @@ def date_validation(date_str):
     try:
         return date.fromisoformat(date_str)
     except ValueError as e:
-        raise argparse.ArgumentTypeError("{}: Date must be in ISO format. ex. 2020-01-01".format(e))
+        raise argparse.ArgumentTypeError("{}: Date must be in ISO format. e.g. 2020-01-01".format(e))
 
 
 if __name__ == '__main__':
     now = datetime.now()
     yesterday = now - timedelta(days=1)
-
     parser = argparse.ArgumentParser(description='export todoist data with certain format')
     parser.add_argument('--api-token',
                         default=os.environ.get('TODOIST_API_TOKEN'))
@@ -23,12 +22,12 @@ if __name__ == '__main__':
                         type=date_validation,
                         default=yesterday.strftime("%Y-%m-%d"),
                         help="From date where you retrieve data. Must be ISO format (YYYY-MM-DD)")
-    parser.add_argument('--to-date',
+    parser.add_argument('--until-date',
                         type=date_validation,
                         default=now.strftime("%Y-%m-%d"),
-                        help="To date where you retrieve data. Must be ISO format (YYYY-MM-DD)")
+                        help="Until date where you retrieve data. Must be ISO format (YYYY-MM-DD)")
     args = parser.parse_args()
     cli = TodoistAPIClient(args.api_token)
     exp = TodoistExport(cli)
-    exp.export(from_dt=args.from_date, to_dt=args.to_date)
-    print("done")
+    res = exp.export(from_dt=args.from_date, to_dt=args.until_date)
+    print(res)

--- a/main.py
+++ b/main.py
@@ -17,7 +17,16 @@ if __name__ == '__main__':
     yesterday = now - timedelta(days=1)
     parser = argparse.ArgumentParser(description='export todoist data with certain format')
     parser.add_argument('--api-token',
-                        default=os.environ.get('TODOIST_API_TOKEN'))
+                        default=os.environ.get('TODOIST_API_TOKEN'),
+                        help='todoist API token')
+    parser.add_argument('--data',
+                        choices=['daily-report'],
+                        help='Data type to be exported',
+                        required=True)
+    parser.add_argument('--format',
+                        default='yaml',
+                        choices=['yaml'],
+                        help='Data export format')
     parser.add_argument('--from-date',
                         type=date_validation,
                         default=yesterday.strftime('%Y-%m-%d'),
@@ -29,5 +38,8 @@ if __name__ == '__main__':
     args = parser.parse_args()
     cli = TodoistAPIClient(args.api_token)
     exp = TodoistExport(cli)
-    res = exp.export(from_dt=args.from_date, until_dt=args.until_date)
-    print(res)
+    if args.data == 'daily-report':
+        res = exp.export_daily_report(from_dt=args.from_date, until_dt=args.until_date, format=args.format)
+        print(res)
+    else:
+        raise argparse.ArgumentError('--data is invalid')

--- a/main.py
+++ b/main.py
@@ -2,14 +2,14 @@
 import argparse
 import os
 from todoist_export import TodoistAPIClient, TodoistExport
-from datetime import date, datetime, timedelta
+from datetime import datetime, timedelta
 
 
 def date_validation(date_str):
     try:
-        return date.fromisoformat(date_str)
+        return datetime.strptime(date_str, '%Y-%m-%d')
     except ValueError as e:
-        raise argparse.ArgumentTypeError("{}: Date must be in ISO format. e.g. 2020-01-01".format(e))
+        raise argparse.ArgumentTypeError('{}: Date must be in ISO format. e.g. 2020-01-01'.format(e))
 
 
 if __name__ == '__main__':
@@ -20,14 +20,14 @@ if __name__ == '__main__':
                         default=os.environ.get('TODOIST_API_TOKEN'))
     parser.add_argument('--from-date',
                         type=date_validation,
-                        default=yesterday.strftime("%Y-%m-%d"),
-                        help="From date where you retrieve data. Must be ISO format (YYYY-MM-DD)")
+                        default=yesterday.strftime('%Y-%m-%d'),
+                        help='From date where you retrieve data. Must be ISO format (YYYY-MM-DD)')
     parser.add_argument('--until-date',
                         type=date_validation,
-                        default=now.strftime("%Y-%m-%d"),
-                        help="Until date where you retrieve data. Must be ISO format (YYYY-MM-DD)")
+                        default=now.strftime('%Y-%m-%d'),
+                        help='Until date where you retrieve data. Must be ISO format (YYYY-MM-DD)')
     args = parser.parse_args()
     cli = TodoistAPIClient(args.api_token)
     exp = TodoistExport(cli)
-    res = exp.export(from_dt=args.from_date, to_dt=args.until_date)
+    res = exp.export(from_dt=args.from_date, until_dt=args.until_date)
     print(res)

--- a/main.py
+++ b/main.py
@@ -2,11 +2,33 @@
 import argparse
 import os
 from todoist_export import TodoistAPIClient, TodoistExport
+from datetime import date, datetime, timedelta
+
+
+def date_validation(date_str):
+    try:
+        return date.fromisoformat(date_str)
+    except ValueError as e:
+        raise argparse.ArgumentTypeError("{}: Date must be in ISO format. ex. 2020-01-01".format(e))
+
 
 if __name__ == '__main__':
+    now = datetime.now()
+    yesterday = now - timedelta(days=1)
+
     parser = argparse.ArgumentParser(description='export todoist data with certain format')
-    parser.add_argument('--api-token', default=os.environ.get('TODOIST_API_TOKEN'))
+    parser.add_argument('--api-token',
+                        default=os.environ.get('TODOIST_API_TOKEN'))
+    parser.add_argument('--from-date',
+                        type=date_validation,
+                        default=yesterday.strftime("%Y-%m-%d"),
+                        help="From date where you retrieve data. Must be ISO format (YYYY-MM-DD)")
+    parser.add_argument('--to-date',
+                        type=date_validation,
+                        default=now.strftime("%Y-%m-%d"),
+                        help="To date where you retrieve data. Must be ISO format (YYYY-MM-DD)")
     args = parser.parse_args()
     cli = TodoistAPIClient(args.api_token)
     exp = TodoistExport(cli)
+    exp.export(from_dt=args.from_date, to_dt=args.to_date)
     print("done")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-pytest==6.2.1
+PyYAML==5.3.1
 todoist-python==8.1.3

--- a/test_todoist_export.py
+++ b/test_todoist_export.py
@@ -8,6 +8,16 @@ def test_TodoistAPIClient___init__():
     assert cli is not None
 
 
+def test_TodoistAPIClient_get_completed_activities():
+    cli = TodoistAPIClient("todoist_token")
+    m = mock.MagicMock(return_value=activity_logs_valid_data)
+    cli.api.activity.get = m
+    from_dt = datetime.strptime('2020-11-10T10:02:03Z', '%Y-%m-%dT%H:%M:%SZ')
+    until_dt = datetime.strptime('2021-01-10T10:02:03Z', '%Y-%m-%dT%H:%M:%SZ') 
+    acts = cli.get_completed_activities(from_dt=from_dt, until_dt=until_dt)
+    assert len(acts) == 3
+
+
 def test_TodoistExport___init__():
     cli = TodoistAPIClient("todoist_token")
     exp = TodoistExport(cli)
@@ -15,8 +25,105 @@ def test_TodoistExport___init__():
 
 
 def test_TodoistExport_export():
-    mcli = mock.MagicMock(return_value="some return value")
+    mcli = mock.MagicMock()
+    mcli.get_completed_activities 
     exp = TodoistExport(mcli)
     now = datetime.now()
     yesterday = now - timedelta(days=1)
     assert exp.export(from_dt=yesterday, to_dt=now, format="yaml") == "TBD"
+
+
+# raw structure from todoist api
+activity_logs_valid_data = {
+    'count': 3,
+    'events': [
+        {
+            'event_date': '2020-12-27T02:30:40Z',
+            'event_type': 'completed',
+            'extra_data': {
+                'client': 'Mozilla/5.0; Todoist/1063',
+                'content': 'test1'
+            },
+            'id': 10600000001,
+            'initiator_id': None,
+            'object_id': 4000000001,
+            'object_type': 'item',
+            'parent_item_id': None,
+            'parent_project_id': 2000000001
+        },
+        {
+            'event_date': '2020-12-27T01:30:40Z',
+            'event_type': 'completed',
+            'extra_data': {
+                'client': 'Mozilla/5.0; Todoist/1063',
+                'content': 'test2'
+            },
+            'id': 10600000002,
+            'initiator_id': None,
+            'object_id': 4000000002,
+            'object_type': 'item',
+            'parent_item_id': None,
+            'parent_project_id': 2000000001
+        },
+        {
+            'event_date': '2020-12-25T01:30:40Z',
+            'event_type': 'completed',
+            'extra_data': {
+                'client': 'Mozilla/5.0; Todoist/1063',
+                'content': 'test3'
+            },
+            'id': 10600000003,
+            'initiator_id': None,
+            'object_id': 4000000003,
+            'object_type': 'item',
+            'parent_item_id': None,
+            'parent_project_id': 3000000001
+        }
+    ]
+}
+
+# activity event data
+activity_valid_data = [
+    {
+        'event_date': '2020-12-27T02:30:40Z',
+        'event_type': 'completed',
+        'extra_data': {
+            'client': 'Mozilla/5.0; Todoist/1063',
+            'content': 'test1'
+        },
+        'id': 10600000001,
+        'initiator_id': None,
+        'object_id': 4000000001,
+        'object_type': 'item',
+        'parent_item_id': None,
+        'parent_project_id': 2000000001
+    },
+    {
+        'event_date': '2020-12-27T01:30:40Z',
+        'event_type': 'completed',
+        'extra_data': {
+            'client': 'Mozilla/5.0; Todoist/1063',
+            'content': 'test2'
+        },
+        'id': 10600000002,
+        'initiator_id': None,
+        'object_id': 4000000002,
+        'object_type': 'item',
+        'parent_item_id': None,
+        'parent_project_id': 2000000001
+    },
+    {
+        'event_date': '2020-12-25T01:30:40Z',
+        'event_type': 'completed',
+        'extra_data': {
+            'client': 'Mozilla/5.0; Todoist/1063',
+            'content': 'test3'
+        },
+        'id': 10600000003,
+        'initiator_id': None,
+        'object_id': 4000000003,
+        'object_type': 'item',
+        'parent_item_id': None,
+        'parent_project_id': 3000000001
+    }
+]

--- a/test_todoist_export.py
+++ b/test_todoist_export.py
@@ -1,6 +1,6 @@
 from todoist_export import TodoistAPIClient, TodoistExport
 from unittest import mock
-from datetime import datetime, timedelta
+from datetime import datetime
 
 
 def test_TodoistAPIClient___init__():
@@ -12,8 +12,8 @@ def test_TodoistAPIClient_get_completed_activities():
     cli = TodoistAPIClient("todoist_token")
     m = mock.MagicMock(return_value=activity_logs_valid_data)
     cli.api.activity.get = m
-    from_dt = datetime.strptime('2020-11-10T10:02:03Z', '%Y-%m-%dT%H:%M:%SZ')
-    until_dt = datetime.strptime('2021-01-10T10:02:03Z', '%Y-%m-%dT%H:%M:%SZ') 
+    from_dt = datetime.strptime('2020-11-10T10:02:03Z', "%Y-%m-%dT%H:%M:%SZ")
+    until_dt = datetime.strptime('2021-01-10T10:02:03Z', "%Y-%m-%dT%H:%M:%SZ")
     acts = cli.get_completed_activities(from_dt=from_dt, until_dt=until_dt)
     assert len(acts) == 3
 
@@ -25,12 +25,12 @@ def test_TodoistExport___init__():
 
 
 def test_TodoistExport_export():
-    mcli = mock.MagicMock()
-    mcli.get_completed_activities 
+    mcli = mock.MagicMock(spec=TodoistAPIClient)
+    mcli.get_completed_activities = mock.MagicMock(return_value=activity_valid_data)
     exp = TodoistExport(mcli)
-    now = datetime.now()
-    yesterday = now - timedelta(days=1)
-    assert exp.export(from_dt=yesterday, to_dt=now, format="yaml") == "TBD"
+    from_dt = datetime.strptime('2020-11-10T10:02:03Z', "%Y-%m-%dT%H:%M:%SZ")
+    until_dt = datetime.strptime('2021-01-10T10:02:03Z', "%Y-%m-%dT%H:%M:%SZ")
+    assert exp.export(from_dt=from_dt, until_dt=until_dt) == activity_valid_data_str
 
 
 # raw structure from todoist api
@@ -127,3 +127,38 @@ activity_valid_data = [
         'parent_project_id': 3000000001
     }
 ]
+
+activity_valid_data_str = """- event_date: '2020-12-27T02:30:40Z'
+  event_type: completed
+  extra_data:
+    client: Mozilla/5.0; Todoist/1063
+    content: test1
+  id: 10600000001
+  initiator_id: null
+  object_id: 4000000001
+  object_type: item
+  parent_item_id: null
+  parent_project_id: 2000000001
+- event_date: '2020-12-27T01:30:40Z'
+  event_type: completed
+  extra_data:
+    client: Mozilla/5.0; Todoist/1063
+    content: test2
+  id: 10600000002
+  initiator_id: null
+  object_id: 4000000002
+  object_type: item
+  parent_item_id: null
+  parent_project_id: 2000000001
+- event_date: '2020-12-25T01:30:40Z'
+  event_type: completed
+  extra_data:
+    client: Mozilla/5.0; Todoist/1063
+    content: test3
+  id: 10600000003
+  initiator_id: null
+  object_id: 4000000003
+  object_type: item
+  parent_item_id: null
+  parent_project_id: 3000000001
+"""

--- a/test_todoist_export.py
+++ b/test_todoist_export.py
@@ -24,13 +24,13 @@ def test_TodoistExport___init__():
     assert exp is not None
 
 
-def test_TodoistExport_export():
+def test_TodoistExport_export_daily_report():
     mcli = mock.MagicMock(spec=TodoistAPIClient)
     mcli.get_completed_activities = mock.MagicMock(return_value=activity_valid_data)
     exp = TodoistExport(mcli)
     from_dt = datetime.strptime('2020-11-10T10:02:03Z', '%Y-%m-%dT%H:%M:%SZ')
     until_dt = datetime.strptime('2021-01-10T10:02:03Z', '%Y-%m-%dT%H:%M:%SZ')
-    assert exp.export(from_dt=from_dt, until_dt=until_dt) == activity_valid_data_str
+    assert exp.export_daily_report(from_dt=from_dt, until_dt=until_dt) == activity_valid_data_str
 
 
 

--- a/test_todoist_export.py
+++ b/test_todoist_export.py
@@ -4,22 +4,22 @@ from datetime import datetime
 
 
 def test_TodoistAPIClient___init__():
-    cli = TodoistAPIClient("todoist_token")
+    cli = TodoistAPIClient('todoist_token')
     assert cli is not None
 
 
 def test_TodoistAPIClient_get_completed_activities():
-    cli = TodoistAPIClient("todoist_token")
+    cli = TodoistAPIClient('todoist_token')
     m = mock.MagicMock(return_value=activity_logs_valid_data)
     cli.api.activity.get = m
-    from_dt = datetime.strptime('2020-11-10T10:02:03Z', "%Y-%m-%dT%H:%M:%SZ")
-    until_dt = datetime.strptime('2021-01-10T10:02:03Z', "%Y-%m-%dT%H:%M:%SZ")
+    from_dt = datetime.strptime('2020-11-10T10:02:03Z', '%Y-%m-%dT%H:%M:%SZ')
+    until_dt = datetime.strptime('2021-01-10T10:02:03Z', '%Y-%m-%dT%H:%M:%SZ')
     acts = cli.get_completed_activities(from_dt=from_dt, until_dt=until_dt)
     assert len(acts) == 3
 
 
 def test_TodoistExport___init__():
-    cli = TodoistAPIClient("todoist_token")
+    cli = TodoistAPIClient('todoist_token')
     exp = TodoistExport(cli)
     assert exp is not None
 
@@ -28,9 +28,10 @@ def test_TodoistExport_export():
     mcli = mock.MagicMock(spec=TodoistAPIClient)
     mcli.get_completed_activities = mock.MagicMock(return_value=activity_valid_data)
     exp = TodoistExport(mcli)
-    from_dt = datetime.strptime('2020-11-10T10:02:03Z', "%Y-%m-%dT%H:%M:%SZ")
-    until_dt = datetime.strptime('2021-01-10T10:02:03Z', "%Y-%m-%dT%H:%M:%SZ")
+    from_dt = datetime.strptime('2020-11-10T10:02:03Z', '%Y-%m-%dT%H:%M:%SZ')
+    until_dt = datetime.strptime('2021-01-10T10:02:03Z', '%Y-%m-%dT%H:%M:%SZ')
     assert exp.export(from_dt=from_dt, until_dt=until_dt) == activity_valid_data_str
+
 
 
 # raw structure from todoist api

--- a/todoist_export.py
+++ b/todoist_export.py
@@ -1,5 +1,7 @@
 import todoist
-from datetime import datetime
+from datetime import datetime, date
+import pprint
+from typing import List
 
 
 class TodoistAPIClient:
@@ -8,12 +10,22 @@ class TodoistAPIClient:
         # auth Todoist API
         self.api = todoist.TodoistAPI(token)
 
+    def get_completed_activities(self, from_dt: datetime, to_dt: datetime) -> List:
+        activities = []
+        # params: https://developer.todoist.com/sync/v8/?shell#get-activity-logs
+        events = self.api.activity.get(object_type="item", event_type="completed", limit=100)
+        # check events are in datetime
+        for ev in events['events']:
+            ev_dt = datetime.strftime(ev.'%Y-%m-%dT%H:%M:%SZ')
+        return activities
+
 
 class TodoistExport:
     def __init__(self, cli: TodoistAPIClient):
         self.cli = cli
 
     def export(self, from_dt: datetime, to_dt: datetime, format: str = "yaml") -> str:
+        acts = self.cli.get_completed_activities()
+        pp = pprint.PrettyPrinter(indent=4)
+        pp.pprint(acts)
         return "TBD"
-        # activities = api.activity.get(object_type="item", event_type="completed", page=1)
-        # pprint.pprint(activities)

--- a/todoist_export.py
+++ b/todoist_export.py
@@ -2,6 +2,7 @@ import todoist
 from datetime import datetime, date
 import pprint
 from typing import List
+import yaml
 
 
 class TodoistAPIClient:
@@ -10,11 +11,13 @@ class TodoistAPIClient:
         # auth Todoist API
         self.api = todoist.TodoistAPI(token)
 
-    def get_completed_activities(self, from_dt: datetime, to_dt: datetime) -> List:
+    def get_completed_activities(self, from_dt: datetime, until_dt: datetime) -> List:
         activities = []
+        # activities are ordered from latest
+        
         # params: https://developer.todoist.com/sync/v8/?shell#get-activity-logs
         events = self.api.activity.get(object_type="item", event_type="completed", limit=100)
-        # check events are in datetime
+        # check events are in range
         for ev in events['events']:
             ev_dt = datetime.strftime(ev.'%Y-%m-%dT%H:%M:%SZ')
         return activities
@@ -24,8 +27,9 @@ class TodoistExport:
     def __init__(self, cli: TodoistAPIClient):
         self.cli = cli
 
-    def export(self, from_dt: datetime, to_dt: datetime, format: str = "yaml") -> str:
-        acts = self.cli.get_completed_activities()
-        pp = pprint.PrettyPrinter(indent=4)
-        pp.pprint(acts)
-        return "TBD"
+    def export(self, from_dt: datetime, until_dt: datetime, format: str = "yaml") -> str:
+        acts = self.cli.get_completed_activities(from_dt=from_dt, until_dt=until_dt)
+        if format in ("yml", "yaml"):
+            return yaml.dump(acts)
+        else:
+            raise ValueError("unsupported format: {}".format(format))

--- a/todoist_export.py
+++ b/todoist_export.py
@@ -2,25 +2,30 @@ import todoist
 from datetime import datetime
 from typing import List
 import yaml
-
+import logging
+import pprint
 
 class TodoistAPIClient:
     def __init__(self, token: str):
         self.token = token
         # auth Todoist API
         self.api = todoist.TodoistAPI(token)
+        self.logger = logging.getLogger(__name__)
 
     def get_completed_activities(self, from_dt: datetime, until_dt: datetime) -> List:
         activities = []
         # params: https://developer.todoist.com/sync/v8/?shell#get-activity-logs
         # TODO: support more than 100 events
         # activities are ordered from latest
-        data = self.api.activity.get(object_type="item", event_type="completed", limit=100)
-        # check events are in range
-        for ev in data['events']:
-            ev_dt = datetime.strptime(ev["event_date"], "%Y-%m-%dT%H:%M:%SZ")
-            if from_dt <= ev_dt and ev_dt <= until_dt:
-                activities.append(ev)
+        data = self.api.activity.get(object_type='item', event_type='completed', limit=100)
+        if 'error' in data:
+            self.logger.error('todoist api returned error: {}'.format(data['error_tag']))
+        else:
+            # check events are in range
+            for ev in data['events']:
+                ev_dt = datetime.strptime(ev['event_date'], '%Y-%m-%dT%H:%M:%SZ')
+                if from_dt <= ev_dt and ev_dt <= until_dt:
+                    activities.append(ev)
         return activities
 
 
@@ -28,9 +33,9 @@ class TodoistExport:
     def __init__(self, cli: TodoistAPIClient):
         self.cli = cli
 
-    def export(self, from_dt: datetime, until_dt: datetime, format: str = "yaml") -> str:
+    def export(self, from_dt: datetime, until_dt: datetime, format: str = 'yaml') -> str:
         acts = self.cli.get_completed_activities(from_dt=from_dt, until_dt=until_dt)
-        if format in ("yml", "yaml"):
+        if format in ('yml', 'yaml'):
             return yaml.dump(acts)
         else:
-            raise ValueError("unsupported format: {}".format(format))
+            raise ValueError('unsupported format: {}'.format(format))

--- a/todoist_export.py
+++ b/todoist_export.py
@@ -1,6 +1,5 @@
 import todoist
-from datetime import datetime, date
-import pprint
+from datetime import datetime
 from typing import List
 import yaml
 
@@ -13,13 +12,15 @@ class TodoistAPIClient:
 
     def get_completed_activities(self, from_dt: datetime, until_dt: datetime) -> List:
         activities = []
-        # activities are ordered from latest
-        
         # params: https://developer.todoist.com/sync/v8/?shell#get-activity-logs
-        events = self.api.activity.get(object_type="item", event_type="completed", limit=100)
+        # TODO: support more than 100 events
+        # activities are ordered from latest
+        data = self.api.activity.get(object_type="item", event_type="completed", limit=100)
         # check events are in range
-        for ev in events['events']:
-            ev_dt = datetime.strftime(ev.'%Y-%m-%dT%H:%M:%SZ')
+        for ev in data['events']:
+            ev_dt = datetime.strptime(ev["event_date"], "%Y-%m-%dT%H:%M:%SZ")
+            if from_dt <= ev_dt and ev_dt <= until_dt:
+                activities.append(ev)
         return activities
 
 

--- a/todoist_export.py
+++ b/todoist_export.py
@@ -33,9 +33,9 @@ class TodoistExport:
     def __init__(self, cli: TodoistAPIClient):
         self.cli = cli
 
-    def export(self, from_dt: datetime, until_dt: datetime, format: str = 'yaml') -> str:
+    def export_daily_report(self, from_dt: datetime, until_dt: datetime, format: str = 'yaml') -> str:
         acts = self.cli.get_completed_activities(from_dt=from_dt, until_dt=until_dt)
-        if format in ('yml', 'yaml'):
+        if format == 'yaml':
             return yaml.dump(acts)
         else:
             raise ValueError('unsupported format: {}'.format(format))


### PR DESCRIPTION
## Why
<!-- Why we need this PR -->
- want to export activity data

## What
<!-- What features are added in this PR -->
- impl function and test
- close: https://github.com/go-zen-chu/todoist-export/issues/1

## QA, Evidence
<!-- Things that support this PR is correct -->

tested with my environment

```
$ python3 main.py --data daily-report --from-date 2021-01-05 --until-date 2021-01-09
- event_date: '2021-01-08T06:00:45Z'
  event_type: completed
  extra_data:
    client: Mozilla/5.0; Todoist/1065
    content: "aaaaaaaaaaaaaaaaaaaa"
  id: 10703095755
  initiator_id: null
  object_id: xxxxxxxx
  object_type: item
  parent_item_id: null
  parent_project_id: xxxxxxxxx
```