### PR TITLE
support local timezone

### DIFF
--- a/main.py
+++ b/main.py
@@ -3,11 +3,28 @@ import argparse
 import os
 from todoist_export import TodoistAPIClient, TodoistExport
 from datetime import datetime, timedelta
+import tzlocal
 
 
-def date_validation(date_str):
+def date_validation(date_str: str):
+    """validate date string and parse with local timezone
+
+    Args:
+        date_str (str): date string
+
+    Raises:
+        argparse.ArgumentTypeError: could not parse date string
+
+    Returns:
+        datetime: datetime object with local timezone
+    """
     try:
-        return datetime.strptime(date_str, '%Y-%m-%d')
+        # support local timezone
+        tz = tzlocal.get_localzone()
+        naive_dt_utc = datetime.strptime(date_str, '%Y-%m-%d')
+        dt = naive_dt_utc.astimezone(tz=tz)
+        print(str(dt))
+        return dt
     except ValueError as e:
         raise argparse.ArgumentTypeError('{}: Date must be in ISO format. e.g. 2020-01-01'.format(e))
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 PyYAML==5.3.1
 todoist-python==8.1.3
+tzlocal==2.1

--- a/test_todoist_export.py
+++ b/test_todoist_export.py
@@ -1,6 +1,6 @@
 from todoist_export import TodoistAPIClient, TodoistExport
 from unittest import mock
-from datetime import datetime
+from datetime import datetime, timezone
 
 
 def test_TodoistAPIClient___init__():
@@ -13,7 +13,9 @@ def test_TodoistAPIClient_get_completed_activities():
     m = mock.MagicMock(return_value=activity_logs_valid_data)
     cli.api.activity.get = m
     from_dt = datetime.strptime('2020-11-10T10:02:03Z', '%Y-%m-%dT%H:%M:%SZ')
+    from_dt = from_dt.astimezone(timezone.utc)
     until_dt = datetime.strptime('2021-01-10T10:02:03Z', '%Y-%m-%dT%H:%M:%SZ')
+    until_dt = until_dt.astimezone(timezone.utc)
     acts = cli.get_completed_activities(from_dt=from_dt, until_dt=until_dt)
     assert len(acts) == 3
 
@@ -29,7 +31,9 @@ def test_TodoistExport_export_daily_report():
     mcli.get_completed_activities = mock.MagicMock(return_value=activity_valid_data)
     exp = TodoistExport(mcli)
     from_dt = datetime.strptime('2020-11-10T10:02:03Z', '%Y-%m-%dT%H:%M:%SZ')
+    from_dt = from_dt.astimezone(timezone.utc)
     until_dt = datetime.strptime('2021-01-10T10:02:03Z', '%Y-%m-%dT%H:%M:%SZ')
+    until_dt = until_dt.astimezone(timezone.utc)
     assert exp.export_daily_report(from_dt=from_dt, until_dt=until_dt) == activity_valid_data_str
 
 

--- a/todoist_export.py
+++ b/todoist_export.py
@@ -1,9 +1,8 @@
 import todoist
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import List
 import yaml
 import logging
-import pprint
 
 class TodoistAPIClient:
     def __init__(self, token: str):
@@ -24,6 +23,8 @@ class TodoistAPIClient:
             # check events are in range
             for ev in data['events']:
                 ev_dt = datetime.strptime(ev['event_date'], '%Y-%m-%dT%H:%M:%SZ')
+                # set naive datetime to tz aware (todoist api returns UTC time)
+                ev_dt = ev_dt.astimezone(timezone.utc)
                 if from_dt <= ev_dt and ev_dt <= until_dt:
                     activities.append(ev)
         return activities


### PR DESCRIPTION
## Why
<!-- Why we need this PR -->
- when you specified from, until for args, it was interpreted as UTC

## What
<!-- What features are added in this PR -->
- support loading local timezone when from, until date are specified

## QA, Evidence
<!-- Things that support this PR is correct -->

debug log on my laptop

```
$ python3 main.py --data daily-report --from-date 2021-01-05 --until-date 2021-01-09
2021-01-05 00:00:00+09:00
2021-01-09 00:00:00+09:00
```

