### PR TITLE
Implement daily report export function

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,21 @@
 # todoist-export
 
-Export todoist data
+Export todoist data via api
 
 ## usage
 
+### export daily report
+
 ```bash
-python3 main.py --data daily-report --from-date 2021-01-05 --until-date 2021-01-09
+$ python3 main.py --data daily-report --from-date 2021-01-05 --until-date 2021-01-09
+'2021-01-05':
+  my-pj:
+  - datetime: '2021-01-05T10:51:24Z'
+    name: task1
+  - datetime: '2021-01-05T09:14:00Z'
+    name: task2
+  - datetime: '2021-01-05T06:47:10Z'
+    name: task3
 ```
 
 ## dev

--- a/main.py
+++ b/main.py
@@ -21,9 +21,8 @@ def date_validation(date_str: str):
     try:
         # support local timezone
         tz = tzlocal.get_localzone()
-        naive_dt_utc = datetime.strptime(date_str, '%Y-%m-%d')
-        dt = naive_dt_utc.astimezone(tz=tz)
-        print(str(dt))
+        naive_dt = datetime.strptime(date_str, '%Y-%m-%d')
+        dt = naive_dt.astimezone(tz=tz)
         return dt
     except ValueError as e:
         raise argparse.ArgumentTypeError('{}: Date must be in ISO format. e.g. 2020-01-01'.format(e))

--- a/todoist_export.py
+++ b/todoist_export.py
@@ -47,6 +47,20 @@ class TodoistExport:
         self.cli = cli
 
     def export_daily_report(self, from_dt: datetime, until_dt: datetime, tz: timezone = timezone.utc, format: str = 'yaml') -> str:
+        """export daily report in string
+
+        Args:
+            from_dt (datetime): from datetime
+            until_dt (datetime): until datetime
+            tz (timezone, optional): timezone for adjustment. Defaults to timezone.utc.
+            format (str, optional): string format. Defaults to 'yaml'.
+
+        Raises:
+            ValueError: error when unsupported format specified
+
+        Returns:
+            str: daily report string
+        """
         acts = self.cli.get_completed_activities(from_dt=from_dt, until_dt=until_dt)
         # report structure:
         # { date: {project: [events]}}


### PR DESCRIPTION
## Why
<!-- Why we need this PR -->
- want to create daily report using todoist api

## What
<!-- What features are added in this PR -->
- create daily report via todoist api

## QA, Evidence
<!-- Things that support this PR is correct -->

I got yaml like below 

```
$ python3 main.py --data daily-report --from-date 2021-01-05 --until-date 2021-01-09
'2021-01-05':
  my-pj:
  - datetime: '2021-01-05T10:51:24Z'
    name: task1
  - datetime: '2021-01-05T09:14:00Z'
    name: task2
  - datetime: '2021-01-05T06:47:10Z'
    name: task3
```

