### PR TITLE
support fetching older activities than last week

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Export todoist data via api
 
 ### export daily report
 
+Export daily report getting completed activities from todoist API.
+
 ```bash
 $ python3 main.py --data daily-report --from-date 2021-01-05 --until-date 2021-01-09
 '2021-01-05':

--- a/main.py
+++ b/main.py
@@ -4,6 +4,7 @@ import os
 from todoist_export import TodoistAPIClient, TodoistExport
 from datetime import datetime, timedelta
 import tzlocal
+from logging import getLogger
 
 
 def date_validation(date_str: str):
@@ -31,7 +32,9 @@ def date_validation(date_str: str):
 
 
 if __name__ == "__main__":
-    now = datetime.now()
+    logger = getLogger(__name__)
+    tz = tzlocal.get_localzone()
+    now = datetime.now(tz=tz)
     yesterday = now - timedelta(days=1)
     parser = argparse.ArgumentParser(
         description="export todoist data with certain format"
@@ -74,6 +77,20 @@ if __name__ == "__main__":
     args = parser.parse_args()
     cli = TodoistAPIClient(args.api_token)
     exp = TodoistExport(cli)
+
+    # args validation
+    if args.from_dt > now:
+        logger.fatal(
+            "from has to be before current time: {} > {}".format(
+                str(args.from_dt), str(now)
+            )
+        )
+    if args.from_dt > args.until_dt:
+        logger.fatal(
+            "from date has to be before until: {}, {}".format(
+                str(args.from_dt), str(args.until_dt)
+            )
+        )
     if args.data == "daily-report":
         tz = tzlocal.get_localzone()
         res = exp.export_daily_report(

--- a/main.py
+++ b/main.py
@@ -79,16 +79,16 @@ if __name__ == "__main__":
     exp = TodoistExport(cli)
 
     # args validation
-    if args.from_dt > now:
+    if args.from_date > now:
         logger.fatal(
             "from has to be before current time: {} > {}".format(
-                str(args.from_dt), str(now)
+                str(args.from_date), str(now)
             )
         )
-    if args.from_dt > args.until_dt:
+    if args.from_date > args.until_date:
         logger.fatal(
             "from date has to be before until: {}, {}".format(
-                str(args.from_dt), str(args.until_dt)
+                str(args.from_date), str(args.until_date)
             )
         )
     if args.data == "daily-report":

--- a/test_todoist_export.py
+++ b/test_todoist_export.py
@@ -3,9 +3,6 @@ from unittest import mock
 from datetime import datetime, timezone
 
 
-now = datetime.now()
-
-
 def test_TodoistAPIClient___init__():
     cli = TodoistAPIClient("todoist_token")
     assert cli is not None

--- a/test_todoist_export.py
+++ b/test_todoist_export.py
@@ -3,6 +3,9 @@ from unittest import mock
 from datetime import datetime, timezone
 
 
+now = datetime.now()
+
+
 def test_TodoistAPIClient___init__():
     cli = TodoistAPIClient("todoist_token")
     assert cli is not None
@@ -10,7 +13,7 @@ def test_TodoistAPIClient___init__():
 
 def test_TodoistAPIClient_get_completed_activities():
     cli = TodoistAPIClient("todoist_token")
-    m = mock.MagicMock(return_value=activity_logs_valid_data)
+    m = mock.MagicMock(side_effect=get_activities_side_effect)
     cli.api.activity.get = m
     from_dt = datetime.strptime("2020-11-10T10:02:03Z", "%Y-%m-%dT%H:%M:%SZ")
     from_dt = from_dt.replace(tzinfo=timezone.utc)
@@ -18,6 +21,7 @@ def test_TodoistAPIClient_get_completed_activities():
     until_dt = until_dt.replace(tzinfo=timezone.utc)
     acts = cli.get_completed_activities(from_dt=from_dt, until_dt=until_dt)
     assert len(acts) == 3
+    # TODO: check future date pattern
 
 
 def test_TodoistExport___init__():
@@ -190,6 +194,21 @@ daily_report_str_pj111 = """'2020-12-27':
   - datetime: '2020-12-27T01:30:40Z'
     name: test2
 """
+
+# variable for singleton pattern
+get_activities_side_effect_returned = False
+
+
+def get_activities_side_effect(
+    object_type="item", event_type="completed", page=0, limit=100
+):
+    global get_activities_side_effect_returned
+    # TODO: proper impl for returning activity data
+    if get_activities_side_effect_returned:
+        return {"count": 0, "events": []}
+    else:
+        get_activities_side_effect_returned = True
+        return activity_logs_valid_data
 
 
 def get_project_side_effect(project_id):


### PR DESCRIPTION
## Why
<!-- Why we need this PR -->
- todoist get activity api **supports get activities up to last week by default**
- we need to take "fetching data older than last week" into consideration

## What
<!-- What features are added in this PR -->
- support fetching older activities than last week

## QA, Evidence
<!-- Things that support this PR is correct -->

- [x]  run command in actual env

```
$ python3 main.py --data daily-report --from-date 2021-01-05 --until-date 2021-01-20

'2021-01-05':
  tasks:
  - datetime: '2021-01-05T10:51:24Z'
    name: xxx
  - datetime: '2021-01-05T09:14:00Z'
    name: yyyy
'2021-01-07':
  tasks:
  - datetime: '2021-01-07T06:08:58Z'
    name: xxxxxxxx
……

'2021-01-17':
  private tasks:
  - datetime: '2021-01-17T06:02:24Z'
    name: ppppppppppp
```

could get old data :)

