### PR TITLE
support due date based report generation & using completed items API

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import argparse
+import logging
 import os
 from todoist_export import TodoistAPIClient, TodoistExport
 from datetime import datetime, timedelta
@@ -32,13 +33,14 @@ def date_validation(date_str: str):
 
 
 if __name__ == "__main__":
-    logger = getLogger(__name__)
     tz = tzlocal.get_localzone()
     now = datetime.now(tz=tz)
     yesterday = now - timedelta(days=1)
     parser = argparse.ArgumentParser(
         description="export todoist data with certain format"
     )
+    parser.add_argument("--debug", action="store_true")
+
     parser.add_argument(
         "--api-token",
         type=str,
@@ -75,8 +77,12 @@ if __name__ == "__main__":
         help="Until date where you retrieve data. Must be ISO format (YYYY-MM-DD)",
     )
     args = parser.parse_args()
-    cli = TodoistAPIClient(args.api_token)
-    exp = TodoistExport(cli)
+    logging.basicConfig(format="[%(asctime)s][%(name)s][%(levelname)s]:\t%(message)s")
+    log_level = logging.DEBUG if args.debug else logging.WARN
+    logger = logging.getLogger(__name__)
+    logger.setLevel(level=log_level)
+    cli = TodoistAPIClient(token=args.api_token, log_level=log_level)
+    exp = TodoistExport(cli=cli, log_level=log_level)
 
     # args validation
     if args.from_date > now:

--- a/test_todoist_export.py
+++ b/test_todoist_export.py
@@ -1,37 +1,38 @@
 from todoist_export import TodoistAPIClient, TodoistExport
 from unittest import mock
 from datetime import datetime, timezone
+import testdata
 
 
 def test_TodoistAPIClient___init__():
-    cli = TodoistAPIClient("todoist_token")
+    cli = TodoistAPIClient(token="todoist_token")
     assert cli is not None
 
 
-def test_TodoistAPIClient_get_completed_activities():
-    cli = TodoistAPIClient("todoist_token")
-    m = mock.MagicMock(side_effect=get_activities_side_effect)
-    cli.api.activity.get = m
+def test_TodoistAPIClient_get_completed_items():
+    cli = TodoistAPIClient(token="todoist_token")
+    cli.api.completed.get_all = mock.MagicMock(
+        side_effect=testdata.get_completed_items_side_effect
+    )
+    cli.get_item_info = mock.MagicMock(side_effect=testdata.get_item_info_side_effect)
     from_dt = datetime.strptime("2020-11-10T10:02:03Z", "%Y-%m-%dT%H:%M:%SZ")
     from_dt = from_dt.replace(tzinfo=timezone.utc)
     until_dt = datetime.strptime("2021-01-10T10:02:03Z", "%Y-%m-%dT%H:%M:%SZ")
     until_dt = until_dt.replace(tzinfo=timezone.utc)
-    acts = cli.get_completed_activities(from_dt=from_dt, until_dt=until_dt)
-    assert len(acts) == 3
-    # TODO: check future date pattern
+    acts = cli.get_completed_items(from_dt=from_dt, until_dt=until_dt)
+    assert len(acts) == 5
 
 
 def test_TodoistExport___init__():
-    cli = TodoistAPIClient("todoist_token")
+    cli = TodoistAPIClient(token="todoist_token")
     exp = TodoistExport(cli)
     assert exp is not None
 
 
 def test_TodoistExport_export_daily_report():
     mcli = mock.MagicMock(spec=TodoistAPIClient)
-    mcli.get_completed_activities = mock.MagicMock(return_value=activity_valid_data)
-    mcli.get_project = mock.MagicMock(side_effect=get_project_side_effect)
-    exp = TodoistExport(mcli)
+    mcli.get_completed_items = mock.MagicMock(return_value=testdata.completed_items)
+    exp = TodoistExport(cli=mcli)
 
     # test from, until
     from_dt = datetime.strptime("2020-11-10T10:02:03Z", "%Y-%m-%dT%H:%M:%SZ")
@@ -39,198 +40,23 @@ def test_TodoistExport_export_daily_report():
     until_dt = datetime.strptime("2021-01-10T10:02:03Z", "%Y-%m-%dT%H:%M:%SZ")
     until_dt = until_dt.replace(tzinfo=timezone.utc)
     assert (
-        exp.export_daily_report(from_dt=from_dt, until_dt=until_dt) == daily_report_str
+        exp.export_daily_report(from_dt=from_dt, until_dt=until_dt)
+        == testdata.daily_report_str
     )
 
     # test pj_filter
     filter1 = ".*"
     assert (
         exp.export_daily_report(from_dt=from_dt, until_dt=until_dt, pj_filter=filter1)
-        == daily_report_str
+        == testdata.daily_report_str
     )
     filter2 = "pj1+"
     assert (
         exp.export_daily_report(from_dt=from_dt, until_dt=until_dt, pj_filter=filter2)
-        == daily_report_str_pj111
+        == testdata.daily_report_str_pj111
     )
     filter3 = "xxxx"
     assert (
         exp.export_daily_report(from_dt=from_dt, until_dt=until_dt, pj_filter=filter3)
         == "{}\n"
     )
-
-
-# raw structure from todoist api
-activity_logs_valid_data = {
-    "count": 3,
-    "events": [
-        {
-            "event_date": "2020-12-27T02:30:40Z",
-            "event_type": "completed",
-            "extra_data": {"client": "Mozilla/5.0; Todoist/1063", "content": "test1"},
-            "id": 10600000001,
-            "initiator_id": None,
-            "object_id": 4000000001,
-            "object_type": "item",
-            "parent_item_id": None,
-            "parent_project_id": 2000000001,
-        },
-        {
-            "event_date": "2020-12-27T01:30:40Z",
-            "event_type": "completed",
-            "extra_data": {"client": "Mozilla/5.0; Todoist/1063", "content": "test2"},
-            "id": 10600000002,
-            "initiator_id": None,
-            "object_id": 4000000002,
-            "object_type": "item",
-            "parent_item_id": None,
-            "parent_project_id": 2000000001,
-        },
-        {
-            "event_date": "2020-12-25T01:30:40Z",
-            "event_type": "completed",
-            "extra_data": {"client": "Mozilla/5.0; Todoist/1063", "content": "test3"},
-            "id": 10600000003,
-            "initiator_id": None,
-            "object_id": 4000000003,
-            "object_type": "item",
-            "parent_item_id": None,
-            "parent_project_id": 3000000001,
-        },
-    ],
-}
-
-# activity event data
-activity_valid_data = [
-    {
-        "event_date": "2020-12-27T02:30:40Z",
-        "event_type": "completed",
-        "extra_data": {"client": "Mozilla/5.0; Todoist/1063", "content": "test1"},
-        "id": 10600000001,
-        "initiator_id": None,
-        "object_id": 4000000001,
-        "object_type": "item",
-        "parent_item_id": None,
-        "parent_project_id": 2000000001,
-    },
-    {
-        "event_date": "2020-12-27T01:30:40Z",
-        "event_type": "completed",
-        "extra_data": {"client": "Mozilla/5.0; Todoist/1063", "content": "test2"},
-        "id": 10600000002,
-        "initiator_id": None,
-        "object_id": 4000000002,
-        "object_type": "item",
-        "parent_item_id": None,
-        "parent_project_id": 2000000001,
-    },
-    {
-        "event_date": "2020-12-25T01:30:40Z",
-        "event_type": "completed",
-        "extra_data": {"client": "Mozilla/5.0; Todoist/1063", "content": "test3"},
-        "id": 10600000003,
-        "initiator_id": None,
-        "object_id": 4000000003,
-        "object_type": "item",
-        "parent_item_id": None,
-        "parent_project_id": 3000000001,
-    },
-]
-
-activity_valid_data_str = """- event_date: '2020-12-27T02:30:40Z'
-  event_type: completed
-  extra_data:
-    client: Mozilla/5.0; Todoist/1063
-    content: test1
-  id: 10600000001
-  initiator_id: null
-  object_id: 4000000001
-  object_type: item
-  parent_item_id: null
-  parent_project_id: 2000000001
-- event_date: '2020-12-27T01:30:40Z'
-  event_type: completed
-  extra_data:
-    client: Mozilla/5.0; Todoist/1063
-    content: test2
-  id: 10600000002
-  initiator_id: null
-  object_id: 4000000002
-  object_type: item
-  parent_item_id: null
-  parent_project_id: 2000000001
-- event_date: '2020-12-25T01:30:40Z'
-  event_type: completed
-  extra_data:
-    client: Mozilla/5.0; Todoist/1063
-    content: test3
-  id: 10600000003
-  initiator_id: null
-  object_id: 4000000003
-  object_type: item
-  parent_item_id: null
-  parent_project_id: 3000000001
-"""
-
-daily_report_str = """'2020-12-25':
-  pj222:
-  - datetime: '2020-12-25T01:30:40Z'
-    name: test3
-'2020-12-27':
-  pj111:
-  - datetime: '2020-12-27T02:30:40Z'
-    name: test1
-  - datetime: '2020-12-27T01:30:40Z'
-    name: test2
-"""
-
-daily_report_str_pj111 = """'2020-12-27':
-  pj111:
-  - datetime: '2020-12-27T02:30:40Z'
-    name: test1
-  - datetime: '2020-12-27T01:30:40Z'
-    name: test2
-"""
-
-# variable for singleton pattern
-get_activities_side_effect_returned = False
-
-
-def get_activities_side_effect(
-    object_type="item", event_type="completed", page=0, limit=100
-):
-    global get_activities_side_effect_returned
-    # TODO: proper impl for returning activity data
-    if get_activities_side_effect_returned:
-        return {"count": 0, "events": []}
-    else:
-        get_activities_side_effect_returned = True
-        return activity_logs_valid_data
-
-
-def get_project_side_effect(project_id):
-    d = {
-        "2000000001": {
-            "child_order": 0,
-            "collapsed": 0,
-            "color": 1,
-            "id": 2000000001,
-            "is_archived": 0,
-            "is_deleted": 0,
-            "is_favorite": 0,
-            "name": "pj111",
-            "parent_id": None,
-        },
-        "3000000001": {
-            "child_order": 0,
-            "collapsed": 0,
-            "color": 1,
-            "id": 3000000001,
-            "is_archived": 0,
-            "is_deleted": 0,
-            "is_favorite": 0,
-            "name": "pj222",
-            "parent_id": None,
-        },
-    }
-    return d[str(project_id)]

--- a/testdata.py
+++ b/testdata.py
@@ -1,0 +1,368 @@
+import datetime
+from datetime import timezone
+
+
+def get_completed_items_side_effect(since, until, limit):
+    d = {
+        "2020-11-10T10:02": {
+            "items": [
+                {
+                    "completed_date": "2020-11-13T15:32:51Z",
+                    "content": "test0",
+                    "id": 1012059080,
+                    "meta_data": None,
+                    "project_id": 2000000000,
+                    "task_id": 5000885110,
+                    "user_id": 10000000,
+                },
+                {
+                    "completed_date": "2020-11-10T10:44:15Z",
+                    "content": "test1",
+                    "id": 1012059081,
+                    "meta_data": None,
+                    "project_id": 2000000000,
+                    "task_id": 5000885111,
+                    "user_id": 10000000,
+                },
+                {
+                    "completed_date": "2020-11-12T10:43:40Z",
+                    "content": "test2",
+                    "id": 1012059082,
+                    "meta_data": None,
+                    "project_id": 2000000001,
+                    "task_id": 5000885112,
+                    "user_id": 10000000,
+                },
+            ],
+            "projects": {
+                "2000000000": {
+                    "child_order": 2,
+                    "collapsed": 0,
+                    "color": 35,
+                    "id": 2000000000,
+                    "is_archived": 0,
+                    "is_deleted": 0,
+                    "is_favorite": 0,
+                    "name": "tasks",
+                    "parent_id": None,
+                    "shared": False,
+                    "sync_id": None,
+                },
+                "2000000001": {
+                    "child_order": 2,
+                    "collapsed": 0,
+                    "color": 35,
+                    "id": 2000000001,
+                    "is_archived": 0,
+                    "is_deleted": 0,
+                    "is_favorite": 0,
+                    "name": "tasks",
+                    "parent_id": None,
+                    "shared": False,
+                    "sync_id": None,
+                },
+            },
+        },
+        "2020-11-17T10:02": {
+            "items": [
+                {
+                    "completed_date": "2020-11-18T11:32:51Z",
+                    "content": "test3",
+                    "id": 1012059083,
+                    "meta_data": None,
+                    "project_id": 2000000000,
+                    "task_id": 5000885113,
+                    "user_id": 10000000,
+                },
+            ],
+            "projects": {
+                "2000000000": {
+                    "child_order": 2,
+                    "collapsed": 0,
+                    "color": 35,
+                    "id": 2000000000,
+                    "is_archived": 0,
+                    "is_deleted": 0,
+                    "is_favorite": 0,
+                    "name": "tasks",
+                    "parent_id": None,
+                    "shared": False,
+                    "sync_id": None,
+                }
+            },
+        },
+        "2020-11-24T10:02": {},
+        "2020-12-01T10:02": {},
+        "2020-12-08T10:02": {},
+        "2020-12-15T10:02": {},
+        "2020-12-22T10:02": {},
+        "2020-12-29T10:02": {},
+        "2021-01-05T10:02": {
+            "items": [
+                {
+                    "completed_date": "2021-01-11T11:32:51Z",
+                    "content": "test4",
+                    "id": 1012059084,
+                    "meta_data": None,
+                    "project_id": 2000000000,
+                    "task_id": 5000885114,
+                    "user_id": 10000000,
+                },
+            ],
+            "projects": {
+                "2000000000": {
+                    "child_order": 2,
+                    "collapsed": 0,
+                    "color": 35,
+                    "id": 2000000000,
+                    "is_archived": 0,
+                    "is_deleted": 0,
+                    "is_favorite": 0,
+                    "name": "tasks",
+                    "parent_id": None,
+                    "shared": False,
+                    "sync_id": None,
+                }
+            },
+        },
+    }
+    return d[since]
+
+
+def get_item_info_side_effect(task_id):
+    d = {
+        5000885110: {
+            "added_by_uid": 10000000,
+            "assigned_by_uid": None,
+            "checked": 1,
+            "child_order": 10,
+            "collapsed": 0,
+            "content": "test0",
+            "date_added": "2020-11-10T01:12:12Z",
+            "date_completed": "2020-11-13T15:32:51Z",
+            "due": {
+                "date": "2020-11-10T11:32:00Z",
+                "is_recurring": False,
+                "lang": "en",
+                "string": "2020-11-10 20:32",
+                "timezone": "Asia/Tokyo",
+            },
+            "id": 5000885110,
+            "in_history": 1,
+            "is_deleted": 0,
+            "labels": [],
+            "parent_id": None,
+            "priority": 1,
+            "project_id": 2000000000,
+            "responsible_uid": None,
+            "section_id": None,
+            "sync_id": None,
+            "user_id": 10000000,
+        },
+        5000885111: {
+            "added_by_uid": 10000000,
+            "assigned_by_uid": None,
+            "checked": 1,
+            "child_order": 10,
+            "collapsed": 0,
+            "content": "test1",
+            "date_added": "2020-11-10T10:42:15",
+            "date_completed": "2020-11-10T10:44:15",
+            "id": 5000885110,
+            "in_history": 1,
+            "is_deleted": 0,
+            "labels": [],
+            "parent_id": None,
+            "priority": 1,
+            "project_id": 2000000000,
+            "responsible_uid": None,
+            "section_id": None,
+            "sync_id": None,
+            "user_id": 10000000,
+        },
+        5000885112: {
+            "added_by_uid": 10000000,
+            "assigned_by_uid": None,
+            "checked": 1,
+            "child_order": 10,
+            "collapsed": 0,
+            "content": "test2",
+            "date_added": "2020-11-10T10:43:40Z",
+            "date_completed": "2020-11-12T10:43:40Z",
+            "due": {
+                "date": "2021-05-10T11:32:00Z",
+                "is_recurring": True,
+                "lang": "en",
+                "string": "2020-05-10 20:32",
+                "timezone": "Asia/Tokyo",
+            },
+            "id": 5000885112,
+            "in_history": 1,
+            "is_deleted": 0,
+            "labels": [],
+            "parent_id": None,
+            "priority": 1,
+            "project_id": 2000000001,
+            "responsible_uid": None,
+            "section_id": None,
+            "sync_id": None,
+            "user_id": 10000000,
+        },
+        5000885113: {
+            "added_by_uid": 10000000,
+            "assigned_by_uid": None,
+            "checked": 1,
+            "child_order": 10,
+            "collapsed": 0,
+            "content": "test3",
+            "date_added": "2020-11-01T11:32:51Z",
+            "date_completed": "2020-11-18T11:32:51Z",
+            "due": {
+                "date": "2020-11-18T20:32:51Z",
+                "is_recurring": False,
+                "lang": "en",
+                "string": "2020-11-19 5:32",
+                "timezone": "Asia/Tokyo",
+            },
+            "id": 5000885113,
+            "in_history": 1,
+            "is_deleted": 0,
+            "labels": [],
+            "parent_id": None,
+            "priority": 1,
+            "project_id": 2000000000,
+            "responsible_uid": None,
+            "section_id": None,
+            "sync_id": None,
+            "user_id": 10000000,
+        },
+        5000885114: {
+            "added_by_uid": 10000000,
+            "assigned_by_uid": None,
+            "checked": 1,
+            "child_order": 10,
+            "collapsed": 0,
+            "content": "test4",
+            "date_added": "2021-01-01T11:32:51Z",
+            "date_completed": "2021-01-11T11:32:51Z",
+            "due": {
+                "date": "2021-01-09T11:32:51",
+                "is_recurring": False,
+                "lang": "en",
+                "string": "2021-01-09 11:32",
+                "timezone": None,
+            },
+            "id": 5000885114,
+            "in_history": 1,
+            "is_deleted": 0,
+            "labels": [],
+            "parent_id": None,
+            "priority": 1,
+            "project_id": 2000000000,
+            "responsible_uid": None,
+            "section_id": None,
+            "sync_id": None,
+            "user_id": 10000000,
+        },
+    }
+    return d[task_id]
+
+
+completed_items = [
+    {
+        "content": "test0",
+        "project_id": 2000000000,
+        "project_name": "pj111",
+        "completed_date": datetime.datetime(
+            2020, 11, 10, 1, 12, 12, tzinfo=timezone.utc
+        ),
+        "due": {
+            "date": datetime.datetime(2020, 11, 10, 11, 32, 00, tzinfo=timezone.utc),
+            "is_recurring": False,
+        },
+    },
+    {
+        "content": "test1",
+        "project_id": 2000000000,
+        "project_name": "pj111",
+        "completed_date": datetime.datetime(
+            2020, 11, 10, 10, 44, 15, tzinfo=timezone.utc
+        ),
+        "due": {
+            "date": None,
+            "is_recurring": False,
+        },
+    },
+    {
+        "content": "test2",
+        "project_id": 2000000001,
+        "project_name": "pj222",
+        "completed_date": datetime.datetime(
+            2020, 11, 12, 10, 43, 40, tzinfo=timezone.utc
+        ),
+        "due": {
+            "date": datetime.datetime(2021, 5, 10, 11, 32, 00, tzinfo=timezone.utc),
+            "is_recurring": True,
+        },
+    },
+    {
+        "content": "test3",
+        "project_id": 2000000000,
+        "project_name": "pj111",
+        "completed_date": datetime.datetime(
+            2020, 11, 18, 11, 32, 51, tzinfo=timezone.utc
+        ),
+        "due": {
+            "date": datetime.datetime(2020, 11, 18, 20, 32, 51, tzinfo=timezone.utc),
+            "is_recurring": False,
+        },
+    },
+    {
+        "content": "test4",
+        "project_id": 2000000000,
+        "project_name": "pj111",
+        "completed_date": datetime.datetime(
+            2021, 1, 11, 11, 32, 51, tzinfo=timezone.utc
+        ),
+        "due": {
+            "date": datetime.datetime(2021, 1, 9, 11, 32, 51, tzinfo=timezone.utc),
+            "is_recurring": False,
+        },
+    },
+]
+
+daily_report_str = """'2020-11-10':
+  pj111:
+  - date: 2020-11-10T11:32:00+0000
+    name: test0
+  - date: 2020-11-10T10:44:15+0000
+    name: test1
+'2020-11-12':
+  pj222:
+  - date: 2020-11-12T10:43:40+0000
+    name: test2
+'2020-11-18':
+  pj111:
+  - date: 2020-11-18T20:32:51+0000
+    name: test3
+'2021-01-09':
+  pj111:
+  - date: 2021-01-09T11:32:51+0000
+    name: test4
+"""
+
+daily_report_str_pj111 = """'2020-11-10':
+  pj111:
+  - date: 2020-11-10T11:32:00+0000
+    name: test0
+  - date: 2020-11-10T10:44:15+0000
+    name: test1
+'2020-11-18':
+  pj111:
+  - date: 2020-11-18T20:32:51+0000
+    name: test3
+'2021-01-09':
+  pj111:
+  - date: 2021-01-09T11:32:51+0000
+    name: test4
+"""


### PR DESCRIPTION
## Why
<!-- Why we need this PR -->
- closes: https://github.com/go-zen-chu/todoist-export/issues/12
- closes: https://github.com/go-zen-chu/todoist-export/issues/11
- support 

## What
<!-- What features are added in this PR -->
- support due date based report generation & using completed items API
- support --debug option

## QA, Evidence
<!-- Things that support this PR is correct -->

```
$ python3 main.py --data daily-report --from-date 2021-02-01 --until-date 2021-02-06 --debug
[2021-03-04 00:36:02,802][todoist_export][INFO]:        get completed items from week before 2021-02-01 00:00:00+09:00 to 2021-02-06 00:00:00+09:00

'2021-02-01':
  tasks:
  - date: '2021-02-01T13:00:00'
    name: aaaaa
  - date: '2021-02-01T06:57:00'
    name: bbbbb
  - date: '2021-02-01T06:20:00'
    name: ccccccccc
  - date: '2021-02-01T02:00:00'
    name: dddd
  - date: '2021-02-01T03:00:00'
    name: eeeee
  - date: '2021-02-01T01:11:39'
    name: ffffff
'2021-02-02':
  tasks:
  - date: '2021-02-02T11:30:00'
    name: gggg
  - date: '2021-02-02T10:18:00'
    name: hhhhh
```

