### PR TITLE
update sync api to v9 and removed todoist-python

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8]
+        python-version: [3.11]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Python package
+name: test 
 
 on: [push]
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # todoist-export
 
-[![Actions Status](https://github.com/go-zen-chu/todoist-export/workflows/ci/badge.svg)](https://github.com/go-zen-chu/todoist-export/actions)
+[![Actions Status](https://github.com/go-zen-chu/todoist-export/workflows/test/badge.svg)](https://github.com/go-zen-chu/todoist-export/actions)
 [![GitHub issues](https://img.shields.io/github/issues/go-zen-chu/todoist-export.svg)](https://github.com/go-zen-chu/todoist-export/issues)
 
 Export todoist data via api

--- a/main.py
+++ b/main.py
@@ -5,7 +5,6 @@ import os
 from todoist_export import TodoistAPIClient, TodoistExport
 from datetime import datetime, timedelta
 import tzlocal
-from logging import getLogger
 
 
 def date_validation(date_str: str):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,3 @@
-backports.zoneinfo==0.2.1
-certifi==2022.12.7
-charset-normalizer==2.1.1
-idna==3.4
-pytz-deprecation-shim==0.1.0.post0
 PyYAML==6.0
 requests==2.28.1
-tzdata==2022.7
 tzlocal==4.2
-urllib3==1.26.13

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,10 @@
-PyYAML==5.4
-todoist-python==8.1.3
-tzlocal==2.1
+backports.zoneinfo==0.2.1
+certifi==2022.12.7
+charset-normalizer==2.1.1
+idna==3.4
+pytz-deprecation-shim==0.1.0.post0
+PyYAML==6.0
+requests==2.28.1
+tzdata==2022.7
+tzlocal==4.2
+urllib3==1.26.13

--- a/test_todoist_export.py
+++ b/test_todoist_export.py
@@ -9,18 +9,30 @@ def test_TodoistAPIClient___init__():
     assert cli is not None
 
 
-def test_TodoistAPIClient_get_completed_items():
+def test_TodoistAPIClient_get_item_info():
+    item_id = "1012059080"
     cli = TodoistAPIClient(token="todoist_token")
-    cli.api.completed.get_all = mock.MagicMock(
-        side_effect=testdata.get_completed_items_side_effect
-    )
-    cli.get_item_info = mock.MagicMock(side_effect=testdata.get_item_info_side_effect)
+    # TIPS: __get method is private so following mock doesn't work
+    # cli.__get = mock.MagicMock(side_effect=testdata.get_side_effect)
+    with mock.patch.object(
+        target=cli, attribute="_TodoistAPIClient__get", new=testdata.get_side_effect
+    ):
+        acts = cli.get_item_info(item_id=item_id)
+        assert acts["content"] == "test0"
+
+
+def test_TodoistAPIClient_get_completed_items():
     from_dt = datetime.strptime("2020-11-10T10:02:03Z", "%Y-%m-%dT%H:%M:%SZ")
     from_dt = from_dt.replace(tzinfo=timezone.utc)
     until_dt = datetime.strptime("2021-01-10T10:02:03Z", "%Y-%m-%dT%H:%M:%SZ")
     until_dt = until_dt.replace(tzinfo=timezone.utc)
-    acts = cli.get_completed_items(from_dt=from_dt, until_dt=until_dt)
-    assert len(acts) == 5
+    cli = TodoistAPIClient(token="todoist_token")
+    cli.get_item_info = mock.MagicMock(side_effect=testdata.get_item_info_side_effect)
+    with mock.patch.object(
+        target=cli, attribute="_TodoistAPIClient__get", new=testdata.get_side_effect
+    ):
+        acts = cli.get_completed_items(from_dt=from_dt, until_dt=until_dt)
+        assert len(acts) == 5
 
 
 def test_TodoistExport___init__():

--- a/test_todoist_export.py
+++ b/test_todoist_export.py
@@ -35,15 +35,18 @@ def test_TodoistAPIClient_get_completed_items():
         assert len(acts) == 5
 
     # test with irregular data
-    cli.get_item_info = mock.MagicMock(
-        side_effect=testdata.get_irregular_item_info_side_effect
-    )
     from_dt = datetime.strptime("2020-11-10T10:02:03Z", "%Y-%m-%dT%H:%M:%SZ")
     from_dt = from_dt.replace(tzinfo=timezone.utc)
     until_dt = datetime.strptime("2021-01-10T10:02:03Z", "%Y-%m-%dT%H:%M:%SZ")
     until_dt = until_dt.replace(tzinfo=timezone.utc)
-    acts = cli.get_completed_items(from_dt=from_dt, until_dt=until_dt)
-    assert len(acts) == 5
+    cli.get_item_info = mock.MagicMock(
+        side_effect=testdata.get_irregular_item_info_side_effect
+    )
+    with mock.patch.object(
+        target=cli, attribute="_TodoistAPIClient__get", new=testdata.get_side_effect
+    ):
+        acts = cli.get_completed_items(from_dt=from_dt, until_dt=until_dt)
+        assert len(acts) == 5
 
 
 def test_TodoistExport___init__():

--- a/testdata.py
+++ b/testdata.py
@@ -2,144 +2,209 @@ import datetime
 from datetime import timezone
 
 
-def get_completed_items_side_effect(since, until, limit):
-    d = {
-        "2020-11-10T10:02": {
-            "items": [
-                {
-                    "completed_date": "2020-11-13T15:32:51Z",
+def get_side_effect(endpoint_path: str, headers=None, params=None):
+    if endpoint_path == "items/get":
+        item_id = params["item_id"]
+        d = {
+            "1012059080": {
+                "ancestors": [],
+                "item": {
+                    "added_at": "2020-11-12T10:52:56.650340Z",
+                    "checked": False,
+                    "child_order": 12,
+                    "collapsed": False,
+                    "completed_at": "2020-11-13T15:32:51.000000Z",
                     "content": "test0",
-                    "id": 1012059080,
-                    "meta_data": None,
-                    "project_id": 2000000000,
-                    "task_id": 5000885110,
-                    "user_id": 10000000,
+                    "description": "",
+                    "due": {
+                        "date": "2021-01-13T06:30:00Z",
+                        "is_recurring": True,
+                        "lang": "en",
+                        "string": "every mon at 15:30",
+                        "timezone": "Asia/Tokyo",
+                    },
+                    "id": "1012059080",
+                    "is_deleted": False,
+                    "labels": [],
+                    "parent_id": None,
+                    "priority": 1,
+                    "project_id": "2000000000",
+                    "responsible_uid": None,
+                    "section_id": "600000",
+                    "sync_id": None,
+                    "user_id": "10000000",
                 },
-                {
-                    "completed_date": "2020-11-10T10:44:15Z",
-                    "content": "test1",
-                    "id": 1012059081,
-                    "meta_data": None,
-                    "project_id": 2000000000,
-                    "task_id": 5000885111,
-                    "user_id": 10000000,
-                },
-                {
-                    "completed_date": "2020-11-12T10:43:40Z",
-                    "content": "test2",
-                    "id": 1012059082,
-                    "meta_data": None,
-                    "project_id": 2000000001,
-                    "task_id": 5000885112,
-                    "user_id": 10000000,
-                },
-            ],
-            "projects": {
-                "2000000000": {
+                "notes": [],
+                "projects": {
                     "child_order": 2,
-                    "collapsed": 0,
-                    "color": 35,
-                    "id": 2000000000,
-                    "is_archived": 0,
-                    "is_deleted": 0,
-                    "is_favorite": 0,
+                    "collapsed": False,
+                    "color": "lime_green",
+                    "id": "2000000000",
+                    "is_archived": False,
+                    "is_deleted": False,
+                    "is_favorite": False,
                     "name": "tasks",
                     "parent_id": None,
                     "shared": False,
                     "sync_id": None,
                 },
-                "2000000001": {
-                    "child_order": 2,
-                    "collapsed": 0,
-                    "color": 35,
-                    "id": 2000000001,
-                    "is_archived": 0,
-                    "is_deleted": 0,
-                    "is_favorite": 0,
-                    "name": "tasks",
-                    "parent_id": None,
-                    "shared": False,
+                "section": {
+                    "added_at": "2019-11-07T13:57:18.000000Z",
+                    "archived_at": None,
+                    "collapsed": False,
+                    "id": "600000",
+                    "is_archived": False,
+                    "is_deleted": False,
+                    "name": "test section",
+                    "project_id": "2000000000",
+                    "section_order": 1,
                     "sync_id": None,
+                    "user_id": "10000000",
                 },
             },
-        },
-        "2020-11-17T10:02": {
-            "items": [
-                {
-                    "completed_date": "2020-11-18T11:32:51Z",
-                    "content": "test3",
-                    "id": 1012059083,
-                    "meta_data": None,
-                    "project_id": 2000000000,
-                    "task_id": 5000885113,
-                    "user_id": 10000000,
+        }
+        return d[item_id]
+    elif endpoint_path == "completed/get_all":
+        since = params["since"]
+        d = {
+            "2020-11-10T10:02": {
+                "items": [
+                    {
+                        "completed_at": "2020-11-13T15:32:51.000000Z",
+                        "content": "test0",
+                        "id": "1012059080",
+                        "meta_data": None,
+                        "project_id": "2000000000",
+                        "task_id": "5000885110",
+                        "user_id": "10000000",
+                    },
+                    {
+                        "completed_at": "2020-11-10T10:44:15.000000Z",
+                        "content": "test1",
+                        "id": "1012059081",
+                        "meta_data": None,
+                        "project_id": "2000000000",
+                        "task_id": "5000885111",
+                        "user_id": "10000000",
+                    },
+                    {
+                        "completed_at": "2020-11-12T10:43:40.000000Z",
+                        "content": "test2",
+                        "id": "1012059082",
+                        "meta_data": None,
+                        "project_id": "2000000001",
+                        "task_id": "5000885112",
+                        "user_id": "10000000",
+                    },
+                ],
+                "projects": {
+                    "2000000000": {
+                        "child_order": 2,
+                        "collapsed": False,
+                        "color": "lime_green",
+                        "id": "2000000000",
+                        "is_archived": False,
+                        "is_deleted": False,
+                        "is_favorite": False,
+                        "name": "tasks",
+                        "parent_id": None,
+                        "shared": False,
+                        "sync_id": None,
+                    },
+                    "2000000001": {
+                        "child_order": 2,
+                        "collapsed": False,
+                        "color": "red",
+                        "id": "2000000001",
+                        "is_archived": False,
+                        "is_deleted": False,
+                        "is_favorite": False,
+                        "name": "tasks",
+                        "parent_id": None,
+                        "shared": False,
+                        "sync_id": None,
+                    },
                 },
-            ],
-            "projects": {
-                "2000000000": {
-                    "child_order": 2,
-                    "collapsed": 0,
-                    "color": 35,
-                    "id": 2000000000,
-                    "is_archived": 0,
-                    "is_deleted": 0,
-                    "is_favorite": 0,
-                    "name": "tasks",
-                    "parent_id": None,
-                    "shared": False,
-                    "sync_id": None,
-                }
             },
-        },
-        "2020-11-24T10:02": {},
-        "2020-12-01T10:02": {},
-        "2020-12-08T10:02": {},
-        "2020-12-15T10:02": {},
-        "2020-12-22T10:02": {},
-        "2020-12-29T10:02": {},
-        "2021-01-05T10:02": {
-            "items": [
-                {
-                    "completed_date": "2021-01-11T11:32:51Z",
-                    "content": "test4",
-                    "id": 1012059084,
-                    "meta_data": None,
-                    "project_id": 2000000000,
-                    "task_id": 5000885114,
-                    "user_id": 10000000,
+            "2020-11-17T10:02": {
+                "items": [
+                    {
+                        "completed_at": "2020-11-18T11:32:51.000000Z",
+                        "content": "test3",
+                        "id": "1012059083",
+                        "meta_data": None,
+                        "project_id": "2000000000",
+                        "task_id": "5000885113",
+                        "user_id": "10000000",
+                    },
+                ],
+                "projects": {
+                    "2000000000": {
+                        "child_order": 2,
+                        "collapsed": False,
+                        "color": "lime_green",
+                        "id": "2000000000",
+                        "is_archived": False,
+                        "is_deleted": False,
+                        "is_favorite": False,
+                        "name": "tasks",
+                        "parent_id": None,
+                        "shared": False,
+                        "sync_id": None,
+                    },
                 },
-            ],
-            "projects": {
-                "2000000000": {
-                    "child_order": 2,
-                    "collapsed": 0,
-                    "color": 35,
-                    "id": 2000000000,
-                    "is_archived": 0,
-                    "is_deleted": 0,
-                    "is_favorite": 0,
-                    "name": "tasks",
-                    "parent_id": None,
-                    "shared": False,
-                    "sync_id": None,
-                }
             },
-        },
-    }
-    return d[since]
+            "2020-11-24T10:02": {},
+            "2020-12-01T10:02": {},
+            "2020-12-08T10:02": {},
+            "2020-12-15T10:02": {},
+            "2020-12-22T10:02": {},
+            "2020-12-29T10:02": {},
+            "2021-01-05T10:02": {
+                "items": [
+                    {
+                        "completed_at": "2021-01-11T11:32:51.000000Z",
+                        "content": "test4",
+                        "id": "1012059084",
+                        "meta_data": None,
+                        "project_id": "2000000000",
+                        "task_id": "5000885114",
+                        "user_id": "10000000",
+                    },
+                ],
+                "projects": {
+                    "2000000000": {
+                        "child_order": 2,
+                        "collapsed": False,
+                        "color": "lime_green",
+                        "id": "2000000000",
+                        "is_archived": False,
+                        "is_deleted": False,
+                        "is_favorite": False,
+                        "name": "tasks",
+                        "parent_id": None,
+                        "shared": False,
+                        "sync_id": None,
+                    },
+                },
+            },
+        }
+        return d[since]
+    else:
+        raise NotImplementedError("this endpoint is not implemented")
 
 
-def get_item_info_side_effect(task_id):
+def get_item_info_side_effect(task_id: str):
     d = {
-        5000885110: {
-            "added_by_uid": 10000000,
+        "5000885110": {
+            "added_by_uid": "10000000",
             "assigned_by_uid": None,
             "checked": 1,
             "child_order": 10,
             "collapsed": 0,
             "content": "test0",
             "date_added": "2020-11-10T01:12:12Z",
-            "date_completed": "2020-11-13T15:32:51Z",
+            "completed_at": "2020-11-13T15:32:51.000000Z",
             "due": {
                 "date": "2020-11-10T11:32:00Z",
                 "is_recurring": False,
@@ -147,48 +212,48 @@ def get_item_info_side_effect(task_id):
                 "string": "2020-11-10 20:32",
                 "timezone": "Asia/Tokyo",
             },
-            "id": 5000885110,
+            "id": "5000885110",
             "in_history": 1,
             "is_deleted": 0,
             "labels": [],
             "parent_id": None,
             "priority": 1,
-            "project_id": 2000000000,
+            "project_id": "2000000000",
             "responsible_uid": None,
             "section_id": None,
             "sync_id": None,
-            "user_id": 10000000,
+            "user_id": "10000000",
         },
-        5000885111: {
-            "added_by_uid": 10000000,
+        "5000885111": {
+            "added_by_uid": "10000000",
             "assigned_by_uid": None,
             "checked": 1,
             "child_order": 10,
             "collapsed": 0,
             "content": "test1",
             "date_added": "2020-11-10T10:42:15",
-            "date_completed": "2020-11-10T10:44:15",
-            "id": 5000885110,
+            "completed_at": "2020-11-10T10:44:15.000000Z",
+            "id": "5000885110",
             "in_history": 1,
             "is_deleted": 0,
             "labels": [],
             "parent_id": None,
             "priority": 1,
-            "project_id": 2000000000,
+            "project_id": "2000000000",
             "responsible_uid": None,
             "section_id": None,
             "sync_id": None,
-            "user_id": 10000000,
+            "user_id": "10000000",
         },
-        5000885112: {
-            "added_by_uid": 10000000,
+        "5000885112": {
+            "added_by_uid": "10000000",
             "assigned_by_uid": None,
             "checked": 1,
             "child_order": 10,
             "collapsed": 0,
             "content": "test2",
             "date_added": "2020-11-10T10:43:40Z",
-            "date_completed": "2020-11-12T10:43:40Z",
+            "completed_at": "2020-11-12T10:43:40.000000Z",
             "due": {
                 "date": "2021-05-10T11:32:00Z",
                 "is_recurring": True,
@@ -196,27 +261,27 @@ def get_item_info_side_effect(task_id):
                 "string": "2020-05-10 20:32",
                 "timezone": "Asia/Tokyo",
             },
-            "id": 5000885112,
+            "id": "5000885112",
             "in_history": 1,
             "is_deleted": 0,
             "labels": [],
             "parent_id": None,
             "priority": 1,
-            "project_id": 2000000001,
+            "project_id": "2000000001",
             "responsible_uid": None,
             "section_id": None,
             "sync_id": None,
-            "user_id": 10000000,
+            "user_id": "10000000",
         },
-        5000885113: {
-            "added_by_uid": 10000000,
+        "5000885113": {
+            "added_by_uid": "10000000",
             "assigned_by_uid": None,
             "checked": 1,
             "child_order": 10,
             "collapsed": 0,
             "content": "test3",
             "date_added": "2020-11-01T11:32:51Z",
-            "date_completed": "2020-11-18T11:32:51Z",
+            "completed_at": "2020-11-18T11:32:51.000000Z",
             "due": {
                 "date": "2020-11-18T20:32:51Z",
                 "is_recurring": False,
@@ -224,27 +289,27 @@ def get_item_info_side_effect(task_id):
                 "string": "2020-11-19 5:32",
                 "timezone": "Asia/Tokyo",
             },
-            "id": 5000885113,
+            "id": "5000885113",
             "in_history": 1,
             "is_deleted": 0,
             "labels": [],
             "parent_id": None,
             "priority": 1,
-            "project_id": 2000000000,
+            "project_id": "2000000000",
             "responsible_uid": None,
             "section_id": None,
             "sync_id": None,
-            "user_id": 10000000,
+            "user_id": "10000000",
         },
-        5000885114: {
-            "added_by_uid": 10000000,
+        "5000885114": {
+            "added_by_uid": "10000000",
             "assigned_by_uid": None,
             "checked": 1,
             "child_order": 10,
             "collapsed": 0,
             "content": "test4",
             "date_added": "2021-01-01T11:32:51Z",
-            "date_completed": "2021-01-11T11:32:51Z",
+            "completed_at": "2021-01-11T11:32:51.000000Z",
             "due": {
                 "date": "2021-01-09T11:32:51",
                 "is_recurring": False,
@@ -252,17 +317,17 @@ def get_item_info_side_effect(task_id):
                 "string": "2021-01-09 11:32",
                 "timezone": None,
             },
-            "id": 5000885114,
+            "id": "5000885114",
             "in_history": 1,
             "is_deleted": 0,
             "labels": [],
             "parent_id": None,
             "priority": 1,
-            "project_id": 2000000000,
+            "project_id": "2000000000",
             "responsible_uid": None,
             "section_id": None,
             "sync_id": None,
-            "user_id": 10000000,
+            "user_id": "10000000",
         },
     }
     return d[task_id]
@@ -271,7 +336,7 @@ def get_item_info_side_effect(task_id):
 completed_items = [
     {
         "content": "test0",
-        "project_id": 2000000000,
+        "project_id": "2000000000",
         "project_name": "pj111",
         "completed_date": datetime.datetime(
             2020, 11, 10, 1, 12, 12, tzinfo=timezone.utc
@@ -283,7 +348,7 @@ completed_items = [
     },
     {
         "content": "test1",
-        "project_id": 2000000000,
+        "project_id": "2000000000",
         "project_name": "pj111",
         "completed_date": datetime.datetime(
             2020, 11, 10, 10, 44, 15, tzinfo=timezone.utc
@@ -295,7 +360,7 @@ completed_items = [
     },
     {
         "content": "test2",
-        "project_id": 2000000001,
+        "project_id": "2000000001",
         "project_name": "pj222",
         "completed_date": datetime.datetime(
             2020, 11, 12, 10, 43, 40, tzinfo=timezone.utc
@@ -307,7 +372,7 @@ completed_items = [
     },
     {
         "content": "test3",
-        "project_id": 2000000000,
+        "project_id": "2000000000",
         "project_name": "pj111",
         "completed_date": datetime.datetime(
             2020, 11, 18, 11, 32, 51, tzinfo=timezone.utc
@@ -319,7 +384,7 @@ completed_items = [
     },
     {
         "content": "test4",
-        "project_id": 2000000000,
+        "project_id": "2000000000",
         "project_name": "pj111",
         "completed_date": datetime.datetime(
             2021, 1, 11, 11, 32, 51, tzinfo=timezone.utc

--- a/testdata.py
+++ b/testdata.py
@@ -333,17 +333,17 @@ def get_item_info_side_effect(task_id: str):
     return d[task_id]
 
 
-def get_irregular_item_info_side_effect(task_id):
+def get_irregular_item_info_side_effect(task_id: str):
     d = {
-        5000885110: {
-            "added_by_uid": 10000000,
+        "5000885110": {
+            "added_by_uid": "10000000",
             "assigned_by_uid": None,
             "checked": 1,
             "child_order": 10,
             "collapsed": 0,
-            "content": "test0",
+            "content": "irregular test0",
             "date_added": "2020-11-10T01:12:12Z",
-            "date_completed": "2020-11-13T15:32:51Z",
+            "completed_at": "2020-11-13T15:32:51.000000Z",
             "due": {
                 # unusual format
                 "date": "2020-11-10",
@@ -351,38 +351,38 @@ def get_irregular_item_info_side_effect(task_id):
                 "lang": "en",
                 "string": "2020-11-10",
             },
-            "id": 5000885110,
+            "id": "5000885110",
             "in_history": 1,
             "is_deleted": 0,
             "labels": [],
             "parent_id": None,
             "priority": 1,
-            "project_id": 2000000000,
+            "project_id": "2000000000",
             "responsible_uid": None,
             "section_id": None,
             "sync_id": None,
-            "user_id": 10000000,
+            "user_id": "10000000",
         },
-        5000885111: {
-            "added_by_uid": 10000000,
+        "5000885111": {
+            "added_by_uid": "10000000",
             "assigned_by_uid": None,
             "checked": 1,
             "child_order": 10,
             "collapsed": 0,
-            "content": "test1",
-            "date_added": "2020-11-10T10:42:15",
-            "date_completed": "2020-11-10T10:44:15",
-            "id": 5000885110,
+            "content": "irregular test1",
+            "date_added": "2020-11-10T10:42:15Z",
+            "completed_at": "2020-11-10T10:44:15.000000Z",
+            "id": "5000885110",
             "in_history": 1,
             "is_deleted": 0,
             "labels": [],
             "parent_id": None,
             "priority": 1,
-            "project_id": 2000000000,
+            "project_id": "2000000000",
             "responsible_uid": None,
             "section_id": None,
             "sync_id": None,
-            "user_id": 10000000,
+            "user_id": "10000000",
         },
     }
     if task_id not in d:


### PR DESCRIPTION
## Why
<!-- Why we need this PR -->
- todoist-python library is deprecated
- sync api v8 is deprecated and updated to v9

## What
<!-- What features are added in this PR -->
- support sync api v9 & removed todoist-python dependency

## QA, Evidence
<!-- Things that support this PR is correct -->

```
$ python3 main.py --data daily-report --from-date 2022-12-01 --until-date 2023-01-01 --debug --format txt > ~/Desktop/report.txt                                                                                          (git)-[udpate-sync-api] 
[2022-12-29 10:56:44,929][todoist_export][INFO]:        get completed items from week before 2022-12-01 00:00:00+09:00 to 2022-12-08 00:00:00+09:00
[2022-12-29 10:56:53,204][todoist_export][INFO]:        get completed items from week before 2022-12-08 00:00:00+09:00 to 2022-12-15 00:00:00+09:00
[2022-12-29 10:56:58,407][todoist_export][INFO]:        get completed items from week before 2022-12-15 00:00:00+09:00 to 2022-12-22 00:00:00+09:00
[2022-12-29 10:57:03,464][todoist_export][INFO]:        get completed items from week before 2022-12-22 00:00:00+09:00 to 2022-12-29 00:00:00+09:00
[2022-12-29 10:57:18,666][todoist_export][INFO]:        get completed items from week before 2022-12-29 00:00:00+09:00 to 2023-01-01 00:00:00+09:00
```
